### PR TITLE
Fix link from hyper recipes to the new split objc/swift styleguides

### DIFF
--- a/HYPER_RECIPES.md
+++ b/HYPER_RECIPES.md
@@ -14,4 +14,4 @@ When you are ready to ship, [send us](mailto:ios@hyper.no) the link to your Hype
 
 Thanks, we hope you'll enjoy making some recipes!
 
-PS: You'll get 10000 additional points if you use our [style guidelines](https://github.com/hyperoslo/iOS-playbook/blob/master/STYLE_GUIDELINES.md)
+PS: You'll get 10000 additional points if you use our [style guidelines](style-guidelines/index.md)

--- a/style-guidelines/index.md
+++ b/style-guidelines/index.md
@@ -1,0 +1,6 @@
+# Hyper's Swift Style Guide
+
+Our overarching goals are conciseness, readability, and simplicity.
+
+1. Style guide for [Objective C](ObjC.md)
+1. Style guide for [Swift](Swift.md)


### PR DESCRIPTION
Introduces a new intermediary index.md page to provide on links to the objc and swift related style guidelines