### PR TITLE
Update Objective-C method style

### DIFF
--- a/style-guidelines/ObjC.md
+++ b/style-guidelines/ObjC.md
@@ -96,8 +96,7 @@ if (!error)
 **Initializer**
 
 ```objc
-- (instancetype)initWithFrame:(CGRect)frame
-{
+- (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (!self) return nil;
 
@@ -108,8 +107,7 @@ if (!error)
 **Lazy loading**
 
 ```objc
-- (UILabel *)label
-{
+- (UILabel *)label {
     if (_label) return _label;
 
     _label = [UILabel new];
@@ -166,13 +164,12 @@ In method signatures, there should be a space after the scope (-/+ symbol). Ther
                     andImage:(UIImage *)image;
 ```
 
-In the method implementation opening bracket should **always** be placed in a new line.
+In the method implementation opening bracket should **always** be placed in the same line as the last parameter:
 
 **For Example**:
 ```objc
 - (void)updatePersonWithName:(NSString *)name
-                    andImage:(UIImage *)image
-{
+                    andImage:(UIImage *)image {
     // Implementation
 }
 ```
@@ -325,8 +322,7 @@ Methods that overwrite their parent methods should be grouped in `#pragma mark -
 `init` methods should be structured like this:
 
 ```objc
-- (instancetype)init
-{
+- (instancetype)init {
     self = [super init]; // or call the designated initalizer
     if (!self) return nil;
 
@@ -500,8 +496,7 @@ Text and example taken from the [Cocoa Naming Guidelines](https://developer.appl
 
 Singleton objects should use a thread-safe pattern for creating their shared instance.
 ```objc
-+ (instancetype)sharedInstance
-{
++ (instancetype)sharedInstance {
    static id sharedInstance = nil;
 
    static dispatch_once_t onceToken;


### PR DESCRIPTION
Following our transition to Swift, I thought we should make our Objective-C code more Swift friendly. So it's not a huge pain to jump between them.

Also is more consistent with `if (...) {`, `structs` and more.

One mayor thing is the positioning of the ending bracket  on method implementations. `{`

Also this is pretty simple to fix in your Xcode projects with a "Replace all" call.

**Copy:**
![a](https://cloud.githubusercontent.com/assets/1088217/7177118/66a8113c-e424-11e4-865d-60cebccffede.png)

**Paste + Search:**
![screen shot 2015-04-16 at 10 32](https://cloud.githubusercontent.com/assets/1088217/7177135/8a433ad6-e424-11e4-8f4c-b6c850630b36.png)

**Replace all with [whitespace] + {:**
![d](https://cloud.githubusercontent.com/assets/1088217/7177146/974eb552-e424-11e4-9f65-f1fa771b67e4.png)

**Profit:**
![2bfae7f8ab9a095d1eaac1a3442d40b7](https://cloud.githubusercontent.com/assets/1088217/7177053/0268a664-e424-11e4-9409-db95d2856cde.jpg)