### PR TITLE
4-spaces to complain with Xcode's defaults

### DIFF
--- a/style-guidelines/Swift.md
+++ b/style-guidelines/Swift.md
@@ -110,9 +110,9 @@ If you need to expose a Swift type for use within Objective-C you can provide a 
 
 ## Spacing and Indentation
 
-* Indent using 2 spaces rather than tabs to conserve space and help prevent line wrapping. This should be configured on the project.
+* Indent using 4 spaces rather than tabs to conserve space and help prevent line wrapping. This should be configured on the project.
 
-  ![Xcode indent settings](https://raw.githubusercontent.com/hyperoslo/iOS-playbook/master/assets/xcode-text-settings-swift.png)
+  ![Xcode indent settings](https://raw.githubusercontent.com/bakkenbaeck/iOS-playbook/master/assets/xcode-text-settings-swift.png)
 
 * Method braces and other braces (`if`/`else`/`switch`/`while` etc.) always open on the same line as the statement but close on a new line.
 * Tip: You can re-indent by selecting some code (or ⌘A to select all) and then Control-I (or Editor\Structure\Re-Indent in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.


### PR DESCRIPTION
4-spaces is more welcoming to externals, it's also more common to use 4 spaces than 2 spaces.

Example: https://github.com/hyperoslo/ImagePicker/pull/95